### PR TITLE
Rails の i18n を理解する

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,7 +28,7 @@ class BooksController < ApplicationController
 
     respond_to do |format|
       if @book.save
-        format.html { redirect_to @book, notice: 'Book was successfully created.' }
+        format.html { redirect_to @book, notice: t('.success') }
         format.json { render :show, status: :created, location: @book }
       else
         format.html { render :new }
@@ -42,7 +42,7 @@ class BooksController < ApplicationController
   def update
     respond_to do |format|
       if @book.update(book_params)
-        format.html { redirect_to @book, notice: 'Book was successfully updated.' }
+        format.html { redirect_to @book, notice: t('.success') }
         format.json { render :show, status: :ok, location: @book }
       else
         format.html { render :edit }
@@ -56,7 +56,7 @@ class BooksController < ApplicationController
   def destroy
     @book.destroy
     respond_to do |format|
-      format.html { redirect_to books_url, notice: 'Book was successfully destroyed.' }
+      format.html { redirect_to books_url, notice: t('.success') }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -28,7 +28,7 @@ class BooksController < ApplicationController
 
     respond_to do |format|
       if @book.save
-        format.html { redirect_to @book, notice: t('.success') }
+        format.html { redirect_to @book, notice: t('controllers.common.create.notice_success') }
         format.json { render :show, status: :created, location: @book }
       else
         format.html { render :new }
@@ -42,7 +42,7 @@ class BooksController < ApplicationController
   def update
     respond_to do |format|
       if @book.update(book_params)
-        format.html { redirect_to @book, notice: t('.success') }
+        format.html { redirect_to @book, notice: t('controllers.common.update.notice_success') }
         format.json { render :show, status: :ok, location: @book }
       else
         format.html { render :edit }
@@ -56,7 +56,7 @@ class BooksController < ApplicationController
   def destroy
     @book.destroy
     respond_to do |format|
-      format.html { redirect_to books_url, notice: t('.success') }
+      format.html { redirect_to books_url, notice: t('controllers.common.destroy.notice_success') }
       format.json { head :no_content }
     end
   end

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -1,6 +1,6 @@
-<h1>Editing Book</h1>
+<h1><%= t('.title') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Show', @book %> |
-<%= link_to 'Back', books_path %>
+<%= link_to t('.show'), @book %> |
+<%= link_to t('.back'), books_path %>

--- a/app/views/books/edit.html.erb
+++ b/app/views/books/edit.html.erb
@@ -2,5 +2,5 @@
 
 <%= render 'form', book: @book %>
 
-<%= link_to t('.show'), @book %> |
-<%= link_to t('.back'), books_path %>
+<%= link_to t('views.common.show'), @book %> |
+<%= link_to t('views.common.back'), books_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -5,10 +5,10 @@
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Memo</th>
-      <th>Author</th>
-      <th>Picture</th>
+      <th><%= Book.human_attribute_name(:title) %></th>
+      <th><%= Book.human_attribute_name(:memo) %></th>
+      <th><%= Book.human_attribute_name(:author) %></th>
+      <th><%= Book.human_attribute_name(:picture) %></th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to t('.show'), book %></td>
-        <td><%= link_to t('.edit'), edit_book_path(book) %></td>
-        <td><%= link_to t('.destroy'), book, method: :delete, data: { confirm: t('.confirm') } %></td>
+        <td><%= link_to t('views.common.show'), book %></td>
+        <td><%= link_to t('views.common.edit'), edit_book_path(book) %></td>
+        <td><%= link_to t('views.common.destroy'), book, method: :delete, data: { confirm: t('views.common.confirm') } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to t('.new'), new_book_path %>
+<%= link_to t('views.common.new'), new_book_path %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Books</h1>
+<h1><%= t('.title') %></h1>
 
 <table>
   <thead>
@@ -20,9 +20,9 @@
         <td><%= book.memo %></td>
         <td><%= book.author %></td>
         <td><%= book.picture %></td>
-        <td><%= link_to 'Show', book %></td>
-        <td><%= link_to 'Edit', edit_book_path(book) %></td>
-        <td><%= link_to 'Destroy', book, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to t('.show'), book %></td>
+        <td><%= link_to t('.edit'), edit_book_path(book) %></td>
+        <td><%= link_to t('.destroy'), book, method: :delete, data: { confirm: t('.confirm') } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +30,4 @@
 
 <br>
 
-<%= link_to 'New Book', new_book_path %>
+<%= link_to t('.new'), new_book_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', book: @book %>
 
-<%= link_to t('.back'), books_path %>
+<%= link_to t('views.common.back'), books_path %>

--- a/app/views/books/new.html.erb
+++ b/app/views/books/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Book</h1>
+<h1><%= t('.title') %></h1>
 
 <%= render 'form', book: @book %>
 
-<%= link_to 'Back', books_path %>
+<%= link_to t('.back'), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,22 +1,22 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong><%= Book.human_attribute_name(:title) %>:</strong>
   <%= @book.title %>
 </p>
 
 <p>
-  <strong>Memo:</strong>
+  <strong><%= Book.human_attribute_name(:memo) %>:</strong>
   <%= @book.memo %>
 </p>
 
 <p>
-  <strong>Author:</strong>
+  <strong><%= Book.human_attribute_name(:author) %>:</strong>
   <%= @book.author %>
 </p>
 
 <p>
-  <strong>Picture:</strong>
+  <strong><%= Book.human_attribute_name(:picture) %>:</strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,5 +20,5 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to t('.edit'), edit_book_path(@book) %> |
-<%= link_to t('.back'), books_path %>
+<%= link_to t('views.common.edit'), edit_book_path(@book) %> |
+<%= link_to t('views.common.back'), books_path %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -20,5 +20,5 @@
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
 
-<%= link_to 'Edit', edit_book_path(@book) %> |
-<%= link_to 'Back', books_path %>
+<%= link_to t('.edit'), edit_book_path(@book) %> |
+<%= link_to t('.back'), books_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>BooksApp</title>
+    <title><%= t(:app_name) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= t(:app_name) %></title>
+    <title><%= t('app_name') %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module BooksApp
   class Application < Rails::Application
+    config.i18n.default_locale = :ja
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
 en:
+  app_name: BooksApp
+
   helpers:
     submit:
       create: Create %{model}
@@ -15,3 +17,24 @@ en:
         memo: Memo
         picture: Picture
         title: Title
+
+  books:
+    actions: &book_actions
+      new: :books.new.title
+      show: Show
+      edit: Edit
+      destroy: Destroy
+      back: Back
+      confirm: Are you sure?
+
+    index:
+      <<: *book_actions
+      title: Books
+    new:
+      <<: *book_actions
+      title: New Book
+    show:
+      <<: *book_actions
+    edit:
+      <<: *book_actions
+      title: Editing Book

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,24 @@ en:
       submit: Save %{model}
       update: Update %{model}
 
+  views:
+    common:
+      new: Create New
+      show: Show
+      edit: Edit
+      destroy: Destroy
+      back: Back
+      confirm: Are you sure?
+
+  controllers:
+    common:
+      create:
+        notice_success: Successfully created.
+      update:
+        notice_success: Successfully updated.
+      destroy:
+        notice_success: Successfully destroyed.
+
   activerecord:
     models:
       book: Book
@@ -19,28 +37,9 @@ en:
         title: Title
 
   books:
-    actions: &book_actions
-      new: :books.new.title
-      show: Show
-      edit: Edit
-      destroy: Destroy
-      back: Back
-      confirm: Are you sure?
-
     index:
-      <<: *book_actions
       title: Books
     new:
-      <<: *book_actions
       title: New Book
-    create:
-      success: Book was successfully created.
-    show:
-      <<: *book_actions
     edit:
-      <<: *book_actions
       title: Editing Book
-    update:
-      success: Book was successfully updated.
-    destroy:
-      success: Book was successfully destroyed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,8 +33,14 @@ en:
     new:
       <<: *book_actions
       title: New Book
+    create:
+      success: Book was successfully created.
     show:
       <<: *book_actions
     edit:
       <<: *book_actions
       title: Editing Book
+    update:
+      success: Book was successfully updated.
+    destroy:
+      success: Book was successfully destroyed.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,33 +1,17 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
-  hello: "Hello world"
+  helpers:
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+
+  activerecord:
+    models:
+      book: Book
+
+    attributes:
+      book:
+        author: Author
+        memo: Memo
+        picture: Picture
+        title: Title

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,6 @@
 ja:
+  app_name: 書籍管理アプリ
+
   helpers:
     submit:
       create: 登録する
@@ -15,3 +17,24 @@ ja:
         memo: メモ
         picture: 写真
         title: タイトル
+
+  books:
+    actions: &book_actions
+      new: :books.new.title
+      show: 詳細
+      edit: 編集
+      destroy: 削除
+      back: 戻る
+      confirm: 本当によろしいでしょうか？
+
+    index:
+      <<: *book_actions
+      title: 書籍一覧
+    new:
+      <<: *book_actions
+      title: あたらしい書籍
+    show:
+      <<: *book_actions
+    edit:
+      <<: *book_actions
+      title: 編集中の書籍

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,15 @@ ja:
       submit: 保存する
       update: 更新する
 
+  views:
+    common:
+      new: 新規作成
+      show: 詳細
+      edit: 編集
+      destroy: 削除
+      back: 戻る
+      confirm: 本当によろしいでしょうか？
+
   activerecord:
     models:
       book: 本
@@ -19,26 +28,13 @@ ja:
         title: タイトル
 
   books:
-    actions: &book_actions
-      new: :books.new.title
-      show: 詳細
-      edit: 編集
-      destroy: 削除
-      back: 戻る
-      confirm: 本当によろしいでしょうか？
-
     index:
-      <<: *book_actions
       title: 書籍一覧
     new:
-      <<: *book_actions
       title: あたらしい書籍
     create:
       success: 登録しました。
-    show:
-      <<: *book_actions
     edit:
-      <<: *book_actions
       title: 編集中の書籍
     update:
       success: 更新しました。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,17 @@
+ja:
+  helpers:
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+
+  activerecord:
+    models:
+      book: 本
+
+    attributes:
+      book:
+        author: 著者
+        memo: メモ
+        picture: 写真
+        title: タイトル

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,8 +33,14 @@ ja:
     new:
       <<: *book_actions
       title: あたらしい書籍
+    create:
+      success: 登録しました。
     show:
       <<: *book_actions
     edit:
       <<: *book_actions
       title: 編集中の書籍
+    update:
+      success: 更新しました。
+    destroy:
+      success: 削除しました。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,6 +16,15 @@ ja:
       back: 戻る
       confirm: 本当によろしいでしょうか？
 
+  controllers:
+    common:
+      create:
+        notice_success: 登録しました。
+      update:
+        notice_success: 更新しました。
+      destroy:
+        notice_success: 削除しました。
+
   activerecord:
     models:
       book: 本
@@ -32,11 +41,5 @@ ja:
       title: 書籍一覧
     new:
       title: あたらしい書籍
-    create:
-      success: 登録しました。
     edit:
       title: 編集中の書籍
-    update:
-      success: 更新しました。
-    destroy:
-      success: 削除しました。


### PR DESCRIPTION
### 必須要件

- [x] 英語と日本語の翻訳をconfig/locales配下のYAMLファイルに定義する
- [x] 各画面の表示を翻訳ファイルから取得して表示できるようにする
- [x] デフォルトの表示言語を英語または日本語に切り替えることで、実際に画面の表示が英語と日本語に切り替わる（要スクリーンショット）
- [x] 表示を切り替えるときは「アプリケーションの設定ファイルを変更してサーバー再起動」でOK（ただし、提出時は日本語をデフォルトにすること）
- [x] [Rails 国際化 (i18n) API - Railsガイド](https://railsguides.jp/i18n.html) を読み、使えそうなメソッドがあれば積極的に使う
- [x] rubocopをパスさせる（要スクリーンショット）

### 歓迎要件

- [ ] 画面上のリンクやURLパラメータで英語と日本語を切り替えられる